### PR TITLE
feat: move prisma migration to Docker entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,12 @@ COPY --from=build-stage /nuxtapp/.output/ ./.output/
 COPY --from=build-stage /nuxtapp/package.json ./package.json
 COPY --from=build-stage /nuxtapp/prisma/ ./prisma/
 
-CMD [ "node", ".output/server/index.mjs" ]
+# Create entrypoint script
+RUN echo '#!/bin/sh\n\
+npm install prisma@5.22.0\n\
+npx prisma migrate deploy\n\
+npm run db:seed\n\
+exec node .output/server/index.mjs' > /nuxtapp/entrypoint.sh && \
+chmod +x /nuxtapp/entrypoint.sh
+
+ENTRYPOINT ["/nuxtapp/entrypoint.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,8 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     environment:
       - NODE_ENV=production
       - BASE_URL=https://sigecafe.bellon.dev
@@ -18,7 +19,6 @@ services:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/sigecafe
       - SESSION_REFRESH_SECONDS=10
       - SESSION_MAX_AGE_SECONDS=600
-
     networks:
       - app-network
 
@@ -40,23 +40,6 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-
-  migration:
-    build:
-      context: ./
-      dockerfile: Dockerfile
-    container_name: sigecafe-migration
-    depends_on:
-      postgres:
-        condition: service_healthy
-    command: >
-      sh -c "npm install prisma@5.22.0 &&
-             npx prisma migrate deploy &&
-             npm run db:seed"
-    environment:
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/sigecafe
-    networks:
-      - app-network
 
 networks:
   app-network:


### PR DESCRIPTION
Remove the separate migration service from docker-compose and integrate
prisma migration, deployment, and seeding into the main app container's