### PR TITLE
feat(docker): include scripts directory in final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR /nuxtapp
 COPY --from=build-stage /nuxtapp/.output/ ./.output/
 COPY --from=build-stage /nuxtapp/package.json ./package.json
 COPY --from=build-stage /nuxtapp/prisma/ ./prisma/
+COPY --from=build-stage /nuxtapp/scripts/ ./scripts/
 
 # Create entrypoint script
 RUN echo '#!/bin/sh\n\


### PR DESCRIPTION
Add copying of the scripts/ directory from the build stage to the
final Docker image. This ensures that necessary scripts are available
at, supporting improved container functionality and deployment.