### PR TITLE
feat(offers): allow admin and staff to manage all offers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 RUN npm install
 
+RUN npm run db:migrate
+
+RUN npm run db:seed
+
 RUN npm run build
 
 FROM node:lts as prod-stage
@@ -15,16 +19,5 @@ FROM node:lts as prod-stage
 WORKDIR /nuxtapp
 
 COPY --from=build-stage /nuxtapp/.output/ ./.output/
-COPY --from=build-stage /nuxtapp/package.json ./package.json
-COPY --from=build-stage /nuxtapp/prisma/ ./prisma/
-COPY --from=build-stage /nuxtapp/scripts/ ./scripts/
 
-# Create entrypoint script
-RUN echo '#!/bin/sh\n\
-npm install prisma@5.22.0\n\
-npx prisma migrate deploy\n\
-npm run db:seed\n\
-exec node .output/server/index.mjs' > /nuxtapp/entrypoint.sh && \
-chmod +x /nuxtapp/entrypoint.sh
-
-ENTRYPOINT ["/nuxtapp/entrypoint.sh"]
+CMD [ "node", ".output/server/index.mjs" ]

--- a/app/pages/app/offers.vue
+++ b/app/pages/app/offers.vue
@@ -5,7 +5,7 @@
     </div>
 
     <!-- Offer form -->
-    <Card class="p-4">
+    <Card v-if="!isAdminOrStaff" class="p-4">
       <div class="flex flex-col md:flex-row md:items-end gap-4">
         <div class="w-full md:w-1/4">
           <label class="block text-sm font-medium mb-1">Lado</label>
@@ -104,7 +104,7 @@
                 <td class="px-4 py-2">{{ formatDate(offer.createdAt) }}</td>
                 <td class="px-4 py-2">
                   <button
-                    v-if="isCurrentUserOffer(offer)"
+                    v-if="isCurrentUserOffer(offer) || isAdminOrStaff"
                     @click="cancelOffer(offer)"
                     class="text-gray-500 hover:text-red-600 transition-colors focus:outline-none"
                     title="Cancelar oferta"
@@ -131,7 +131,7 @@
                 <td class="px-4 py-2">{{ formatDate(offer.createdAt) }}</td>
                 <td class="px-4 py-2">
                   <button
-                    v-if="isCurrentUserOffer(offer)"
+                    v-if="isCurrentUserOffer(offer) || isAdminOrStaff"
                     @click="cancelOffer(offer)"
                     class="text-gray-500 hover:text-red-600 transition-colors focus:outline-none"
                     title="Cancelar oferta"
@@ -168,6 +168,12 @@ const priceError = ref<string>('')
 const quantityError = ref<string>('')
 const canChooseSide = ref(true)
 const isSubmitting = ref(false)
+
+// Check if user is admin or staff (ADMINISTRADOR, COOPERATIVA, COLABORADOR)
+const isAdminOrStaff = computed(() => {
+  const userType = usuarioStore.usuarioPreferences?.type
+  return userType === 'ADMINISTRADOR' || userType === 'COOPERATIVA' || userType === 'COLABORADOR'
+})
 
 // Sort asks (sell offers) by price descending (highest price first - same as bids)
 const sortedAsks = computed(() =>

--- a/server/api/offers/[id].ts
+++ b/server/api/offers/[id].ts
@@ -20,6 +20,7 @@ export default defineEventHandler(async (event) => {
   }
 
   const userId = user.id
+  const userType = user.type
 
   // Parse and validate the offer ID
   const offerId = parseInt(event.context.params?.id ?? '0', 10)
@@ -49,8 +50,10 @@ export default defineEventHandler(async (event) => {
 
       const offer = offers[0]
 
-      // Check if offer belongs to user
-      if (offer.userId !== userId) {
+      // Check if user is admin/staff or offer belongs to user
+      const isAdminOrStaff = userType === 'ADMINISTRADOR' || userType === 'COOPERATIVA' || userType === 'COLABORADOR'
+
+      if (!isAdminOrStaff && offer.userId !== userId) {
         console.log(`Unauthorized: Offer belongs to user ${offer.userId}, not ${userId}`)
         throw createError({
           statusCode: 403,


### PR DESCRIPTION
Add a computed property to identify admin or staff users and update
UI logic to enable offer cancellation for these roles regardless of
ownership. Restrict offer form visibility for admin/staff users.

Update API endpoint to permit admin and staff users to cancel any
offer, bypassing ownership checks.

Modify Dockerfile to run database migrations and seed data during
build to ensure the database is up to date before starting the app.