### PR TITLE
chore(docker): expose Postgres port and update credentials

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - NODE_ENV=production
       - BASE_URL=https://sigecafe.bellon.dev
       - AUTH_SECRET=secret
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/sigecafe
+      - DATABASE_URL=postgresql://postgres:shfalkQHhjhHJ@postgres:5432/sigecafe
       - SESSION_REFRESH_SECONDS=10
       - SESSION_MAX_AGE_SECONDS=600
     networks:
@@ -26,10 +26,11 @@ services:
     image: postgres:14
     container_name: sigecafe-postgres
     restart: always
-    # Removed the ports mapping to avoid exposing it externally.
+    ports:
+      - "5432:5432"
     environment:
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_PASSWORD=shfalkQHhjhHJ
       - POSTGRES_DB=sigecafe
     volumes:
       - postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
Add port mapping for Postgres service to allow external access on
5432. Update the Postgres password in environment variables and
DATABASE_URL to enhance security and ensure consistency across the
configuration. These changes enable easier local development and
integration with other services.