### PR TITLE
fix(docker-compose): change postgres port mapping to 54321

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     container_name: sigecafe-postgres
     restart: always
     ports:
-      - "5432:5432"
+      - "54321:5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=shfalkQHhjhHJ


### PR DESCRIPTION
Update the docker-compose.yaml to map the host port 54321 to the container's 5432 port for the sigecafe-postgres service. This change prevents port conflicts on the host machine and allows running multiple Postgres instances concurrently.