### PR TITLE
chore: externalize environment variables in Docker configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ COPY --from=build-stage /nuxtapp/prisma/ ./prisma/
 COPY --from=build-stage /nuxtapp/package.json ./package.json
 COPY --from=build-stage /nuxtapp/package-lock.json ./package-lock.json
 COPY --from=build-stage /nuxtapp/scripts/ ./scripts/
-COPY --from=build-stage /nuxtapp/.env ./.env
 
 # Install only production dependencies and Prisma
 RUN npm install --only=production && \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,12 +13,12 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      - NODE_ENV=production
-      - BASE_URL=https://sigecafe.bellon.dev
-      - AUTH_SECRET=secret
-      - DATABASE_URL=postgresql://postgres:shfalkQHhjhHJ@postgres:5432/sigecafe
-      - SESSION_REFRESH_SECONDS=10
-      - SESSION_MAX_AGE_SECONDS=600
+      - NODE_ENV
+      - BASE_URL
+      - AUTH_SECRET
+      - DATABASE_URL
+      - SESSION_REFRESH_SECONDS
+      - SESSION_MAX_AGE_SECONDS
     networks:
       - app-network
 
@@ -29,9 +29,9 @@ services:
     ports:
       - "54321:5432"
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=shfalkQHhjhHJ
-      - POSTGRES_DB=sigecafe
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - POSTGRES_DB
     volumes:
       - postgres-data:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
Replace hardcoded environment variables in docker-compose.yaml with
variable references to improve security and flexibility. Remove the
copying of the .env file in the Dockerfile to avoid embedding secrets
in the image. These changes enable safer configuration management and
easier deployment across different environments.