### PR TITLE
fix(schema): remove unique constraint from cnpj field

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,7 +46,7 @@ model Cooperativa {
   id            Int           @id @default(autoincrement())
   nome          String
   celular       String?
-  cnpj          String?       @unique
+  cnpj          String?
   endereco      String?
   cidade        String?
   estado        String?


### PR DESCRIPTION
Remove the unique constraint on the cnpj field in the Cooperativa model.
This change allows multiple records to have the same cnpj value, which
is necessary to accommodate cases where cnpj is not unique or may be
shared across entries.