### PR TITLE
feat(db): prevent duplicate cooperativa entries on seed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,19 @@ COPY --from=build-stage /nuxtapp/package.json ./package.json
 COPY --from=build-stage /nuxtapp/package-lock.json ./package-lock.json
 COPY --from=build-stage /nuxtapp/scripts/ ./scripts/
 
+# Install Chrome for Puppeteer
+RUN apt-get update \
+    && apt-get install -y wget gnupg ca-certificates \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set environment variable to skip Puppeteer's Chrome download
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
 # Install only production dependencies and Prisma
 RUN npm install --only=production && \
     npm install -g prisma
@@ -29,7 +42,7 @@ RUN echo '#!/bin/sh\n\
 echo "Waiting for database to be ready..."\n\
 sleep 5\n\
 echo "Running database migrations..."\n\
-npm run db:migrate\n\
+prisma migrate deploy\n\
 echo "Running database seeds..."\n\
 node scripts/db-seed.mjs\n\
 echo "Starting application..."\n\

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       - DATABASE_URL
       - SESSION_REFRESH_SECONDS
       - SESSION_MAX_AGE_SECONDS
+      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
     networks:
       - app-network
 

--- a/server/api/coffee-prices/index.ts
+++ b/server/api/coffee-prices/index.ts
@@ -100,7 +100,11 @@ async function fetchLatestPrices() {
   // Attempt headless browser scraper first
   try {
     // console.log('[fetchLatestPrices] Launching Puppeteer')
-    const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] })
+    const browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+      executablePath: process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD === 'true' ? 'google-chrome-stable' : undefined
+    })
     const page = await browser.newPage()
     // mimic typical browser environment
     await page.setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +


### PR DESCRIPTION
Add a check in db-seed script to skip inserting cooperativa if
a record with the same cnpj already exists. Handle unique
constraint errors gracefully without exiting the process.

fix(docker): install Chrome and configure Puppeteer

Install Google Chrome in the Docker image to support Puppeteer
headless browser usage. Set environment variable to skip
Puppeteer's Chromium download and update Puppeteer launch to
use system Chrome when configured.

ci(docker-compose): add env var to skip Chromium download

Add PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true to docker-compose
environment to align with Dockerfile and Puppeteer launch
configuration.