### PR TITLE
feat: switch to Chromium for Puppeteer and fix comprador fields

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,18 +20,28 @@ COPY --from=build-stage /nuxtapp/package.json ./package.json
 COPY --from=build-stage /nuxtapp/package-lock.json ./package-lock.json
 COPY --from=build-stage /nuxtapp/scripts/ ./scripts/
 
-# Install Chrome for Puppeteer
-RUN apt-get update \
-    && apt-get install -y wget gnupg ca-certificates \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
-      --no-install-recommends \
+# Install dependencies for headless browser alternatives
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libgbm1 \
+    libnspr4 \
+    libnss3 \
+    libu2f-udev \
+    xdg-utils \
+    wget \
+    chromium \
+    --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-# Set environment variable to skip Puppeteer's Chrome download
+# Set Puppeteer environment variables to skip Chrome download and use a different browser
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 # Install only production dependencies and Prisma
 RUN npm install --only=production && \

--- a/app/pages/app/compradores.vue
+++ b/app/pages/app/compradores.vue
@@ -33,22 +33,22 @@ const columns = [
   },
   {
     label: "Documento",
-    field: "associado.documento",
+    field: "comprador.documento",
     type: "text"
   },
   {
     label: "Endereço",
-    field: "associado.endereco",
+    field: "comprador.endereco",
     type: "text"
   },
   {
     label: "Cidade",
-    field: "associado.cidade",
+    field: "comprador.cidade",
     type: "text"
   },
   {
     label: "Estado",
-    field: "associado.estado",
+    field: "comprador.estado",
     type: "select",
     options: [
       { label: "SP", value: "SP" },

--- a/server/api/coffee-prices/index.ts
+++ b/server/api/coffee-prices/index.ts
@@ -103,7 +103,7 @@ async function fetchLatestPrices() {
     const browser = await puppeteer.launch({
       headless: true,
       args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
-      executablePath: process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD === 'true' ? 'google-chrome-stable' : undefined
+      executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined
     })
     const page = await browser.newPage()
     // mimic typical browser environment


### PR DESCRIPTION
Update Dockerfile to install Chromium and related dependencies instead
of Google Chrome, setting Puppeteer to use Chromium via environment
variables. This reduces image size and simplifies browser management.

Modify Puppeteer launch config to use the executable path from the new
environment variable, enabling the switch to Chromium.

Fix field names in compradores.vue to correctly reference comprador
properties instead of associado, ensuring data displays properly.